### PR TITLE
Updated toggle_term to work with eOS JUNO 5.0

### DIFF
--- a/toggle_term
+++ b/toggle_term
@@ -1,5 +1,5 @@
 #!/bin/bash
-my_term=pantheon-terminal
+my_term=io.elememtary.terminal
 my_term_pid=$(xdotool search --class "$my_term")
 if [[ -z "$my_term_pid"  ]]; then
     $my_term &


### PR DESCRIPTION
changed toggle_term to io.elementary.terminal instead of pantheon-terminal so that it works with latest verion of Elementary OS.